### PR TITLE
Add CI build verification, ShellSpec, and job summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,30 @@ jobs:
       - name: Python tests
         run: |
           python/venv/bin/python3 -m pytest --cov --cov-report=term-missing --tb=short 2>&1 | tee /tmp/pytest-output.txt
-          echo "## Python Tests" >> $GITHUB_STEP_SUMMARY
-          grep -E "^(PASSED|FAILED|ERROR|python/|tests/|[0-9]+ passed)" /tmp/pytest-output.txt | tail -5 >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Python Tests"
+            echo ""
+            grep -E "^=+ .* (passed|failed|error|errors) in " /tmp/pytest-output.txt | tail -1 || true
+            awk '
+              /^python\// && $2 ~ /^[0-9]+$/ && $3 ~ /^[0-9]+$/ && $4 ~ /^[0-9]+%$/ {
+                path = $1
+                sub(/^python\//, "", path)
+                rows[++n] = sprintf("| `%s` | %s | %s | **%s** |", path, $2, $3, $4)
+              }
+              END {
+                if (n > 0) {
+                  print ""
+                  print "### Coverage (summary)"
+                  print ""
+                  print "Per-line *Missing* lists stay in the job log only (pytest `term-missing`)."
+                  print ""
+                  print "| Module | Stmts | Miss | Cover |"
+                  print "|--------|------:|-----:|------:|"
+                  for (i = 1; i <= n; i++) print rows[i]
+                }
+              }
+            ' /tmp/pytest-output.txt
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Install system deps for UI tests
         run: sudo apt-get install -y xvfb libgtk-3-0 libgbm-dev libnss3 libasound2


### PR DESCRIPTION
Closes #12, #27, #28

## Summary

- **Build verification** (#27): `npm run pack:linux --publish never` runs on push to main and manual dispatch only - not on every PR. Artifacts uploaded for inspection. Manual dispatch available from the Actions UI to trigger a build on any branch when needed.
- **ShellSpec in CI** (#12): installs ShellSpec via curl and runs the 7 hook tests on every PR
- **Job summary** (#28): each suite appends results to the Actions job summary - Python test count + coverage, UI test count, ShellSpec count, build artifact sizes (on main/dispatch only)

## Trigger matrix

| Trigger | Tests | Build |
|---------|-------|-------|
| Pull request | yes | no |
| Push to main | yes | yes |
| Manual dispatch | yes | yes |

## Test plan

- [x] PR CI passes: lint, audit, Python tests, UI tests, ShellSpec (no build)
- [x] Job summary visible in Actions run with test sections populated
- [ ] Push to main triggers build and produces downloadable artifacts

Assisted by: Claude Sonnet 4.6