### PR TITLE
fix: venv bundle guard for Linux packages (#33)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,16 @@ jobs:
 
       - name: Python venv + deps
         run: |
-          python -m venv python/venv
+          python -m venv python/venv --copies
           python/venv/bin/pip install -U pip
           python/venv/bin/pip install -r python/requirements.txt
           python/venv/bin/pip install pylint
 
       - name: Node install
         run: npm ci
+
+      - name: Node script tests (venv bundle guard)
+        run: npm run test:scripts
 
       - name: Dependency audit
         run: |

--- a/package.json
+++ b/package.json
@@ -6,14 +6,15 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "pack:linux": "electron-builder --linux",
+    "pack:linux": "node scripts/check-venv-for-bundle.js && electron-builder --linux",
     "test:python": "python/venv/bin/python3 -m pytest",
     "lint:python": "python/venv/bin/python3 -m pylint python/pdf_server.py",
     "test:ui": "playwright test",
     "test:ui:report": "playwright show-report tests/ui/report",
     "test:ui:installed": "playwright test --config playwright.installed.config.js",
     "coverage:python": "python/venv/bin/python3 -m pytest --cov --cov-report=term-missing",
-    "test:shell": "shellspec --format documentation"
+    "test:shell": "shellspec --format documentation",
+    "test:scripts": "node --test scripts/check-venv-for-bundle.test.js"
   },
   "dependencies": {
     "pdfjs-dist": "^4.4.168",

--- a/scripts/check-venv-for-bundle.js
+++ b/scripts/check-venv-for-bundle.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/**
+ * electron-builder extraResources copies python/ into the AppImage/deb/rpm.
+ * A normal venv uses absolute symlinks (e.g. python3 -> /usr/bin/python3.12),
+ * which break inside the mount → spawn ENOENT.
+ * Recreate with: python3 -m venv python/venv --copies
+ */
+const fs = require('fs')
+const path = require('path')
+
+/**
+ * @param {string} repoRoot Absolute path to repo root (directory containing `python/`)
+ * @returns {{ ok: true, message: string } | { ok: false, message: string }}
+ */
+function validateVenvForBundle(repoRoot) {
+  const py = path.join(repoRoot, 'python', 'venv', 'bin', 'python3')
+
+  if (!fs.existsSync(py)) {
+    return {
+      ok: false,
+      message:
+        `Missing ${py}\n` +
+        'Create a venv and install deps before pack:linux:\n' +
+        '  python3 -m venv python/venv --copies\n' +
+        '  python/venv/bin/pip install -U pip\n' +
+        '  python/venv/bin/pip install -r python/requirements.txt\n',
+    }
+  }
+
+  let st
+  try {
+    st = fs.lstatSync(py)
+  } catch (e) {
+    return { ok: false, message: `Cannot stat ${py}: ${e.message}` }
+  }
+
+  if (st.isSymbolicLink()) {
+    const target = fs.readlinkSync(py)
+    const resolved = path.resolve(path.dirname(py), target)
+    const venvRoot = path.join(repoRoot, 'python', 'venv')
+    const rel = path.relative(venvRoot, resolved)
+    const inside = rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel))
+    if (!inside) {
+      return {
+        ok: false,
+        message:
+          `python/venv uses symlinks outside the venv (${py} -> ${target}).\n` +
+          'AppImage/deb/rpm need a relocatable venv. Rebuild with:\n' +
+          '  rm -rf python/venv\n' +
+          '  python3 -m venv python/venv --copies\n' +
+          '  python/venv/bin/pip install -U pip\n' +
+          '  python/venv/bin/pip install -r python/requirements.txt\n',
+      }
+    }
+  }
+
+  return { ok: true, message: 'python/venv looks bundle-safe (--copies layout).' }
+}
+
+function main() {
+  const root = path.join(__dirname, '..')
+  const r = validateVenvForBundle(root)
+  if (!r.ok) {
+    console.error(r.message)
+    process.exit(1)
+  }
+  console.log(r.message)
+}
+
+module.exports = { validateVenvForBundle }
+
+if (require.main === module) {
+  main()
+}

--- a/scripts/check-venv-for-bundle.test.js
+++ b/scripts/check-venv-for-bundle.test.js
@@ -1,0 +1,53 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const fs = require('fs')
+const path = require('path')
+const os = require('os')
+
+const { validateVenvForBundle } = require('./check-venv-for-bundle.js')
+
+function mkdirp(p) {
+  fs.mkdirSync(p, { recursive: true })
+}
+
+function makeFakeVenv(repoRoot) {
+  const bin = path.join(repoRoot, 'python', 'venv', 'bin')
+  mkdirp(bin)
+  return bin
+}
+
+test('missing python/venv/bin/python3 → not ok', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'stellar-venv-test-'))
+  const r = validateVenvForBundle(root)
+  assert.strictEqual(r.ok, false)
+  assert.match(r.message, /Missing/)
+})
+
+test('regular file python3 → ok', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'stellar-venv-test-'))
+  const bin = makeFakeVenv(root)
+  const py = path.join(bin, 'python3')
+  fs.writeFileSync(py, '#!/bin/sh\necho\n', { mode: 0o755 })
+  const r = validateVenvForBundle(root)
+  assert.strictEqual(r.ok, true)
+})
+
+test('symlink python3 → python3.12 inside venv → ok', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'stellar-venv-test-'))
+  const bin = makeFakeVenv(root)
+  fs.writeFileSync(path.join(bin, 'python3.12'), '')
+  fs.symlinkSync('python3.12', path.join(bin, 'python3'))
+  const r = validateVenvForBundle(root)
+  assert.strictEqual(r.ok, true)
+})
+
+test('symlink python3 → absolute host interpreter → not ok', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'stellar-venv-test-'))
+  const bin = makeFakeVenv(root)
+  fs.symlinkSync('/usr/bin/python3', path.join(bin, 'python3'))
+  const r = validateVenvForBundle(root)
+  assert.strictEqual(r.ok, false)
+  assert.match(r.message, /symlinks outside the venv/)
+})


### PR DESCRIPTION
## Summary
Closes #33.

- **Pre-pack check**: `npm run pack:linux` runs `scripts/check-venv-for-bundle.js` so we fail fast when `python/venv/bin/python3` is missing or points outside the venv (the AppImage ENOENT case).
- **CI**: `python -m venv python/venv --copies` so push/workflow_dispatch package builds pass the guard.
- **Tests**: `npm run test:scripts` runs `node --test` on `scripts/check-venv-for-bundle.test.js`; wired into CI after `npm ci`.

## Local rebuild (from issue)
```bash
rm -rf python/venv
python3 -m venv python/venv --copies
python/venv/bin/pip install -U pip
python/venv/bin/pip install -r python/requirements.txt
```

Made with [Cursor](https://cursor.com)