### PR TITLE
fix(ci): filter deb binary by file+executable to avoid doc path match

### DIFF
--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -28,12 +28,22 @@ jobs:
             echo "run_id=${{ inputs.run_id }}" >> "$GITHUB_OUTPUT"
             echo "skip=false" >> "$GITHUB_OUTPUT"
           elif [ "${{ github.event.workflow_run.conclusion }}" = "success" ]; then
-            echo "run_id=${{ github.event.workflow_run.id }}" >> "$GITHUB_OUTPUT"
-            echo "skip=false" >> "$GITHUB_OUTPUT"
+            RUN_ID="${{ github.event.workflow_run.id }}"
+            ARTIFACT_COUNT=$(gh api repos/${{ github.repository }}/actions/runs/$RUN_ID/artifacts \
+              --jq '.total_count')
+            if [ "$ARTIFACT_COUNT" -eq 0 ]; then
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              echo "Upstream build succeeded but uploaded no artifacts (likely skipped) — skipping package tests."
+            else
+              echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+              echo "skip=false" >> "$GITHUB_OUTPUT"
+            fi
           else
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "Upstream build did not succeed — skipping package tests."
           fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # ── AppImage ─────────────────────────────────────────────────────────────────
   test-appimage:
@@ -141,7 +151,9 @@ jobs:
       - name: Set binary path
         run: |
           PKG=$(dpkg -l | awk '/stellar/{print $2; exit}')
-          BINARY=$(dpkg -L "$PKG" | grep '/stellar-pdf$')
+          BINARY=$(dpkg -L "$PKG" | grep '/stellar-pdf$' | while IFS= read -r f; do
+            [ -f "$f" ] && [ -x "$f" ] && echo "$f" && break
+          done)
           echo "Found binary: $BINARY (package: $PKG)"
           test -n "$BINARY" && test -f "$BINARY" \
             || { echo "ERROR: stellar-pdf binary not found in package $PKG"; exit 1; }


### PR DESCRIPTION
## Summary

Two fixes to \`package-test.yml\`:

**1. deb binary multi-line match**
\`grep '/stellar-pdf$'\` matched both \`/usr/share/doc/stellar-pdf\` (a directory) and \`/opt/stellarPDF/stellar-pdf\` (the binary), making \`BINARY\` a multi-line string that failed the \`test -f\` assertion. Pipes through a \`while\` loop to return only the first path that is a regular file and executable.

**2. Skip smoke tests when nightly build uploaded no artifacts**
When the nightly build skips due to no new commits, it still exits \`success\`, triggering \`package-test\` which then fails trying to download artifacts that were never uploaded. Now checks artifact count via the GitHub API in \`resolve-artifact\` and sets \`skip=true\` if the upstream run uploaded nothing.

## Test plan

- [ ] \`test-deb\`: "Found binary: /opt/stellarPDF/stellar-pdf" in logs, single line
- [ ] All 7 smoke tests pass for deb
- [ ] Next skipped nightly: \`resolve-artifact\` logs "no artifacts — skipping" and all jobs are skipped

Signed-off-by: brian grech <87876720+BeeGrech@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)