### PR TITLE
feat(ci): gate nightly release on smoke test passage

### DIFF
--- a/.github/workflows/linux-appimage.yml
+++ b/.github/workflows/linux-appimage.yml
@@ -134,7 +134,8 @@ jobs:
           name: stellar-pdf-rpm
           path: dist/*.rpm
 
-      # Rolling prerelease: move tag "nightly" to this commit, then upload asset.
+      # Rolling prerelease: move tag "nightly" to this commit.
+      # Actual release publish happens in package-test.yml after smoke tests pass.
       # If tag protection blocks force-push, remove protection for "nightly" or use dated tags instead.
       - name: Update nightly tag
         if: steps.should_build.outputs.skip != 'true' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
@@ -143,29 +144,6 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -fa nightly -m "Nightly AppImage"
           git push -f origin refs/tags/nightly
-
-      - name: Publish nightly prerelease
-        if: steps.should_build.outputs.skip != 'true' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
-        uses: ncipollo/release-action@v1
-        with:
-          artifacts: "dist/*.AppImage,dist/*.deb,dist/*.rpm"
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag: nightly
-          name: Nightly (Linux)
-          body: |
-            Automated build from commit `${{ github.sha }}` on `${{ github.ref_name }}`.
-
-            | Format | Distro |
-            |--------|--------|
-            | `.AppImage` | Universal |
-            | `.deb` | Ubuntu / Debian |
-            | `.rpm` | Fedora / RHEL |
-
-            [View this workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
-          prerelease: true
-          allowUpdates: true
-          replacesArtifacts: true
-          skipIfReleaseExists: false
 
       - name: Publish release packages (version tag)
         if: steps.should_build.outputs.skip != 'true' && startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -11,7 +11,7 @@ on:
         required: true
 
 permissions:
-  contents: read
+  contents: write
   actions: read
 
 jobs:
@@ -218,3 +218,57 @@ jobs:
         with:
           name: rpm-test-report
           path: tests/ui/report-installed/
+
+  # ── Promote to nightly release (only if all smoke tests pass) ─────────────
+  promote-nightly:
+    needs: [resolve-artifact, test-appimage, test-deb, test-rpm]
+    if: needs.resolve-artifact.outputs.skip != 'true'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Download AppImage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: stellar-pdf-appimage
+          run-id: ${{ needs.resolve-artifact.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: dist/
+
+      - name: Download deb artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: stellar-pdf-deb
+          run-id: ${{ needs.resolve-artifact.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: dist/
+
+      - name: Download rpm artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: stellar-pdf-rpm
+          run-id: ${{ needs.resolve-artifact.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: dist/
+
+      - name: Publish nightly prerelease
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "dist/*"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: nightly
+          name: Nightly (Linux)
+          body: |
+            Smoke-tested build from commit `${{ github.event.workflow_run.head_sha }}`.
+            All three package formats (AppImage, deb, rpm) passed installed smoke tests.
+
+            | Format | Distro |
+            |--------|--------|
+            | `.AppImage` | Universal |
+            | `.deb` | Ubuntu / Debian |
+            | `.rpm` | Fedora / RHEL |
+
+            [Build run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ needs.resolve-artifact.outputs.run_id }}) · [Test run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+          prerelease: true
+          allowUpdates: true
+          removeArtifacts: true
+          replacesArtifacts: true
+          skipIfReleaseExists: false

--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -141,7 +141,9 @@ jobs:
       - name: Set binary path
         run: |
           PKG=$(dpkg -l | awk '/stellar/{print $2; exit}')
-          BINARY=$(dpkg -L "$PKG" | grep '/stellar-pdf$')
+          BINARY=$(dpkg -L "$PKG" | grep '/stellar-pdf$' | while IFS= read -r f; do
+            [ -f "$f" ] && [ -x "$f" ] && echo "$f" && break
+          done)
           echo "Found binary: $BINARY (package: $PKG)"
           test -n "$BINARY" && test -f "$BINARY" \
             || { echo "ERROR: stellar-pdf binary not found in package $PKG"; exit 1; }


### PR DESCRIPTION
## Summary

- Previously `linux-appimage.yml` published packages to the nightly release immediately after building — before smoke tests ran. A broken build shipped to users with no automated gate.
- Removes "Publish nightly prerelease" from the build workflow
- Adds a `promote-nightly` job to `package-test.yml` that only runs after **all three** smoke test jobs pass (`test-appimage`, `test-deb`, `test-rpm`)
- Uses `removeArtifacts: true` on promotion — clears stale assets before upload, fixing the accumulated old-version artifacts on the release page
- Release body now links both the build run and the test run

## New flow

1. **Build** → test → upload CI artifacts → update nightly tag (no release publish)
2. **Smoke tests** → if all pass → promote to nightly GitHub Release

## Test plan

- [ ] Next nightly: release only appears after all smoke tests pass
- [ ] If any smoke test fails: no release published, broken build stays off the releases page
- [ ] Release page shows exactly 3 assets with no stale leftovers

Signed-off-by: brian grech <87876720+BeeGrech@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)