### PR TITLE
fix(ci): build pdf_server in manylinux2014 for glibc 2.17+ compatibility

### DIFF
--- a/.github/workflows/linux-appimage.yml
+++ b/.github/workflows/linux-appimage.yml
@@ -105,12 +105,18 @@ jobs:
           name: playwright-report
           path: tests/ui/report/
 
-      - name: Build PyInstaller standalone binary
+      - name: Build PyInstaller standalone binary (manylinux2014 for glibc 2.17+ compat)
         if: steps.should_build.outputs.skip != 'true'
         run: |
-          python/venv/bin/pyinstaller --onefile --name pdf_server \
-            --distpath python/dist python/pdf_server.py
-          chmod +x python/dist/pdf_server
+          docker run --rm -v "$(pwd):/work" -w /work \
+            quay.io/pypa/manylinux2014_x86_64 \
+            bash -c "
+              /opt/python/cp312-cp312/bin/python3 -m venv python/venv_build &&
+              python/venv_build/bin/pip install -q PyMuPDF pyinstaller &&
+              python/venv_build/bin/pyinstaller --onefile --name pdf_server \
+                --distpath python/dist python/pdf_server.py &&
+              chmod +x python/dist/pdf_server
+            "
 
       - name: Build AppImage + deb + rpm
         if: steps.should_build.outputs.skip != 'true'


### PR DESCRIPTION
Closes #47

## Problem

The PyInstaller binary was built on Ubuntu 22.04 (glibc 2.35), causing it to fail on older distros with:
```
GLIBC_2.35 not found (required by libpython3.12.so.1.0)
```
Confirmed failing on Alma Linux 8 (glibc 2.28), surfacing as the "PDF server exited code 255" error in the UI.

## Fix

Run the PyInstaller step inside a `manylinux2014` container via `docker run`. The Ubuntu 22.04 runner has Docker available so no workflow restructuring is needed - just that one step is wrapped.

`manylinux2014` (PEP 599) targets glibc >= 2.17, covering:
- Alma Linux 8 / RHEL 8 (glibc 2.28)
- Ubuntu 20.04 (glibc 2.31)
- Ubuntu 22.04 (glibc 2.35)
- Fedora 40 (glibc 2.39)
- Anything from the last 10+ years

## Test plan

- [ ] Build completes successfully with the manylinux2014 container step
- [ ] `ldd python/dist/pdf_server` shows no GLIBC_2.35 requirement
- [ ] AppImage runs without "PDF server exited" error on Alma Linux 8

Signed-off-by: brian grech <87876720+BeeGrech@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)