### PR TITLE
fix(ci): switch pdf_server build to almalinux:8 (manylinux2014 lacks --enable-shared)

### DIFF
--- a/.github/workflows/linux-appimage.yml
+++ b/.github/workflows/linux-appimage.yml
@@ -105,13 +105,14 @@ jobs:
           name: playwright-report
           path: tests/ui/report/
 
-      - name: Build PyInstaller standalone binary (manylinux2014 for glibc 2.17+ compat)
+      - name: Build PyInstaller standalone binary (almalinux:8 for glibc 2.28+ compat)
         if: steps.should_build.outputs.skip != 'true'
         run: |
           docker run --rm -v "$(pwd):/work" -w /work \
-            quay.io/pypa/manylinux2014_x86_64 \
+            almalinux:8 \
             bash -c "
-              /opt/python/cp312-cp312/bin/python3 -m venv python/venv_build &&
+              dnf install -y python3.11 &&
+              python3.11 -m venv python/venv_build &&
               python/venv_build/bin/pip install -q PyMuPDF pyinstaller &&
               python/venv_build/bin/pyinstaller --onefile --name pdf_server \
                 --distpath python/dist python/pdf_server.py &&


### PR DESCRIPTION
Follow-up to #49.

## Problem

manylinux2014 CPython builds lack `--enable-shared` which PyInstaller requires:
```
ERROR: Python was built without a shared library, which is required by PyInstaller.
```

## Fix

Switch to `almalinux:8` which provides `python3.11` built with shared library support. glibc 2.28 in that image covers Alma/RHEL 8 and all newer major distros - which is the confirmed failing case from #47.

## Test plan

- [ ] Build step completes without the shared library error
- [ ] `ldd python/dist/pdf_server` shows no GLIBC > 2.28 requirement
- [ ] AppImage runs without error on Alma Linux 8

Signed-off-by: brian grech <87876720+BeeGrech@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)